### PR TITLE
extract-edgeworth-romfile: fix uninitialized variable

### DIFF
--- a/extract-edgeworth-romfile.c
+++ b/extract-edgeworth-romfile.c
@@ -66,7 +66,7 @@ int main( int argc, char** argv ) {
 	unsigned char *workbuf = NULL, *resultbuf = NULL;
 	linetype curline;
 	arcEntry *filelist = NULL;
-	FILE *f, *t, *o;
+	FILE *f, *t = NULL, *o;
 	
 	if( !(f = fopen( argv[1], "rb" ))) {
 		printf("Couldnt open file %s\n", argv[1]);


### PR DESCRIPTION
This fixes a segfault with the newest version of gcc when a list of file names isn't provided.